### PR TITLE
Aseta PHP:n aikavyöhykkeeksi Helsingin aikavyöhyke

### DIFF
--- a/uusi-ulkoasu/asetukset.php
+++ b/uusi-ulkoasu/asetukset.php
@@ -1,0 +1,5 @@
+<?php
+
+date_default_timezone_set('Europe/Helsinki');
+
+## EOF

--- a/uusi-ulkoasu/yla.php
+++ b/uusi-ulkoasu/yla.php
@@ -1,3 +1,4 @@
+<?php require_once 'asetukset.php' ?>
 <!DOCTYPE html>
 <html lang="fi">
 


### PR DESCRIPTION
Muuten PHP saattaa varoittaa aikavyöhykkeen puuttumisesta joka kerta,
kun päivämääriä tai aikoja yritetään näyttää sivuilla