### PR TITLE
Lisää editorconfig tiedosto

### DIFF
--- a/uusi-ulkoasu/.editorconfig
+++ b/uusi-ulkoasu/.editorconfig
@@ -1,0 +1,9 @@
+# editorconfig.org
+root = true
+
+[*]
+indent_style = tab
+indent_size = 2
+charset = utf-8
+trim_trailing_whitespace = false
+insert_final_newline = false


### PR DESCRIPTION
EditorConfig on työkalu, joka auttaa ohjelmistokehittäjiä käyttämään
samaa koodityyliä eri projekteissa.

EditorConfigia varten löytyy mm. Sublimeen lisäosa nimellä
"EditorConfig", jonka voi ladata sublime package managerilla.

Hukkapuron kooditapa näyttää olevan käyttää tab-merkkejä välilyöntien
sijasta sekä jättää laittamatta viimeistä rivinvaihtoa tiedostoihin
automaattisesti.